### PR TITLE
Fix connection check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = 'online.hatsunemiku'
-version = '1.0.2'
+version = '1.0.3'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/ServerStartView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/ServerStartView.java
@@ -21,6 +21,8 @@ import com.vaadin.flow.router.Route;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+
+import feign.FeignException;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.startup.TachideskMaintainer;
 import org.slf4j.Logger;
@@ -127,7 +129,7 @@ public class ServerStartView extends VerticalLayout {
   }
 
   private void checkConnection() {
-    String url = settingsService.getSettings().getUrl() + "/api/v1/meta";
+    String url = settingsService.getSettings().getUrl() + "/api/v1/settings/about";
 
     try {
       var response = client.getForEntity(url, Void.class);
@@ -147,7 +149,7 @@ public class ServerStartView extends VerticalLayout {
 
         executor.shutdownNow();
       }
-    } catch (Exception e) {
+    } catch (FeignException e) {
       logger.debug("No Connection to Server yet", e);
     }
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/ServerStartView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/ServerStartView.java
@@ -18,11 +18,10 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.progressbar.ProgressBar;
 import com.vaadin.flow.router.Route;
+import feign.FeignException;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-
-import feign.FeignException;
 import online.hatsunemiku.tachideskvaadinui.services.SettingsService;
 import online.hatsunemiku.tachideskvaadinui.startup.TachideskMaintainer;
 import org.slf4j.Logger;


### PR DESCRIPTION
The server connection verification route was updated from "/api/v1/meta" to "/api/v1/settings/about". The change was required as the previous endpoint relied on SQL data which is not guaranteed to be available at the moment of the check, causing potential connection testing failure. Exception handling was also refined to specifically catch FeignExceptions.
This issue should now be fixed/easier to spot