### PR TITLE
Add workflow for Winget releases

### DIFF
--- a/.github/workflows/publish-winget-release.yaml
+++ b/.github/workflows/publish-winget-release.yaml
@@ -1,0 +1,14 @@
+  on:
+    release:
+      types: [published]
+  jobs:
+    publish:
+      runs-on: windows-latest
+      steps:
+        - name: Winget Releaser
+          uses: vedantmgoyal2009/winget-releaser@v2
+          with:
+            identifier: Suwayomi.Tachidesk-VaadinUI
+            installers-regex: '\.msi$'
+            token: ${{ secrets.WINGET_TOKEN }}
+            fork-user: aless2003


### PR DESCRIPTION
This commit adds a new workflow to automatically publish releases to Winget. It uses the vedantmgoyal2009/winget-releaser action and is triggered whenever a new release is published.