### PR TITLE
Fixing AniListView authentication bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'online.hatsunemiku'
-version = '1.6.0'
+version = '1.6.1'
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/linux/flatpak/online.hatsune_miku.tachidesk-vaadinui.appdata.xml
+++ b/linux/flatpak/online.hatsune_miku.tachidesk-vaadinui.appdata.xml
@@ -42,14 +42,9 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="1.6.0" date="2024-04-08">
+        <release version="1.6.1" date="2024-04-09">
             <description>
-                <p>VaadinUI now uses Suwayomi's authentication System. Enables MyAnimeList authentication.</p>
-                <p>Note: Don't use MAL Authentication with Suwayomi Server v1.0.0-r1498 as it's bugged</p>
-                <ul>
-                    <li>Added a Strip Reader Implementation for vertical reading</li>
-                    <li>Enhanced design for cards</li>
-                </ul>
+                <p>Fixed a bug with AniList import authentication</p>
             </description>
         </release>
     </releases>

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/trackers/AniListView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/trackers/AniListView.java
@@ -23,7 +23,7 @@ import online.hatsunemiku.tachideskvaadinui.view.layout.TrackingLayout;
 public class AniListView extends TrackingLayout {
 
   private final AniListAPIService aniListAPI;
-  private final MangaList list;
+  private MangaList list;
 
   /**
    * AniListView is a view for displaying AniList entries to import.
@@ -36,7 +36,10 @@ public class AniListView extends TrackingLayout {
     addClassName("anilist-view");
 
     this.aniListAPI = apiService;
-    this.list = apiService.getMangaList();
+
+    if (hasToken()) {
+      this.list = apiService.getMangaList();
+    }
 
     init();
   }
@@ -61,6 +64,15 @@ public class AniListView extends TrackingLayout {
 
   @Override
   public Div getReadingSection() {
+    //Only need to check in this method since all other methods get called after this one
+    if (list == null) {
+      if (!hasToken()) {
+        throw new IllegalStateException("getReadingSection called without token");
+      }
+
+      list = aniListAPI.getMangaList();
+    }
+
     var cards = getCards(list.reading());
 
     return getContentSection("Reading", cards);

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/trackers/AniListView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/trackers/AniListView.java
@@ -64,7 +64,7 @@ public class AniListView extends TrackingLayout {
 
   @Override
   public Div getReadingSection() {
-    //Only need to check in this method since all other methods get called after this one
+    // Only need to check in this method since all other methods get called after this one
     if (list == null) {
       if (!hasToken()) {
         throw new IllegalStateException("getReadingSection called without token");


### PR DESCRIPTION
Fixing a bug where when navigating to the AniList Import View, the site would throw an exception if there wasn't a token available already