### PR TITLE
Added Meta Info API Service for Suwayomi

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -21,10 +21,11 @@ public class ServerVersion {
 
   /**
    * Creates a new instance of the {@link ServerVersion} class.
+   *
    * @param version the version of the server
    * @param revision the revision of the server
    */
-  //Private constructor so only Spring can create instances of this class
+  // Private constructor so only Spring can create instances of this class
   @JsonCreator
   private ServerVersion(String version, String revision) {
     this.version = version;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -6,6 +6,7 @@
 
 package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 
 /** Represents the version of the Suwayomi Server. */
@@ -18,7 +19,14 @@ public class ServerVersion {
   /** The revision of the server. Format: r1234 */
   private final String revision;
 
-  public ServerVersion(String version, String revision) {
+  /**
+   * Creates a new instance of the {@link ServerVersion} class.
+   * @param version the version of the server
+   * @param revision the revision of the server
+   */
+  //Private constructor so only Spring can create instances of this class
+  @JsonCreator
+  private ServerVersion(String version, String revision) {
     this.version = version;
     this.revision = revision;
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -11,13 +11,10 @@ import lombok.Getter;
 @Getter
 public class ServerVersion {
 
-  /**
-   * The version of the server. Format: vX.Y.Z
-   */
+  /** The version of the server. Format: vX.Y.Z */
   private final String version;
-  /**
-   * The revision of the server. Format: r1234
-   */
+
+  /** The revision of the server. Format: r1234 */
   private final String revision;
 
   public ServerVersion(String version, String revision) {
@@ -71,5 +68,4 @@ public class ServerVersion {
     String revisionNumber = revision.substring(1);
     return Integer.parseInt(revisionNumber);
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -8,6 +8,9 @@ package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import lombok.Getter;
 
+/**
+ * Represents the version of the Suwayomi Server.
+ */
 @Getter
 public class ServerVersion {
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -8,9 +8,7 @@ package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import lombok.Getter;
 
-/**
- * Represents the version of the Suwayomi Server.
- */
+/** Represents the version of the Suwayomi Server. */
 @Getter
 public class ServerVersion {
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/ServerVersion.java
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
+
+import lombok.Getter;
+
+@Getter
+public class ServerVersion {
+
+  /**
+   * The version of the server. Format: vX.Y.Z
+   */
+  private final String version;
+  /**
+   * The revision of the server. Format: r1234
+   */
+  private final String revision;
+
+  public ServerVersion(String version, String revision) {
+    this.version = version;
+    this.revision = revision;
+  }
+
+  /**
+   * Gets the major version of the server. For example if the version is v1.2.3, this method will
+   * return 1.
+   *
+   * @return the major version of the server
+   */
+  public int getMajorVersion() {
+    String majorVersion = version.substring(1, version.indexOf('.'));
+    return Integer.parseInt(majorVersion);
+  }
+
+  /**
+   * Gets the minor version of the server. For example if the version is v1.2.3, this method will
+   * return 2.
+   *
+   * @return the minor version of the server
+   */
+  public int getMinorVersion() {
+    int firstDot = version.indexOf('.');
+    int secondDot = version.indexOf('.', firstDot + 1);
+    String minorVersion = version.substring(firstDot + 1, secondDot);
+    return Integer.parseInt(minorVersion);
+  }
+
+  /**
+   * Gets the patch version of the server. For example if the version is v1.2.3, this method will
+   * return 3.
+   *
+   * @return the patch version of the server
+   */
+  public int getPatchVersion() {
+    int lastDot = version.lastIndexOf('.');
+    String patchVersion = version.substring(lastDot + 1);
+    return Integer.parseInt(patchVersion);
+  }
+
+  /**
+   * Gets the revision number of the server. For example if the revision is r1234, this method will
+   * return 1234.
+   *
+   * @return the revision number of the server
+   */
+  public int getRevisionNumber() {
+    String revisionNumber = revision.substring(1);
+    return Integer.parseInt(revisionNumber);
+  }
+
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package online.hatsunemiku.tachideskvaadinui.services;
+
+import java.util.Optional;
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.ServerVersion;
+import online.hatsunemiku.tachideskvaadinui.services.client.suwayomi.SuwayomiMetaClient;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SuwayomiService {
+
+  private final SuwayomiMetaClient metaClient;
+
+  public SuwayomiService(SuwayomiMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
+  public Optional<ServerVersion> getServerVersion() {
+    try {
+      return Optional.of(metaClient.getServerVersion());
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -27,5 +27,4 @@ public class SuwayomiService {
       return Optional.empty();
     }
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -11,6 +11,11 @@ import online.hatsunemiku.tachideskvaadinui.data.tachidesk.ServerVersion;
 import online.hatsunemiku.tachideskvaadinui.services.client.suwayomi.SuwayomiMetaClient;
 import org.springframework.stereotype.Service;
 
+/**
+ * Responsible for retrieving data from the Suwayomi Server. This class is an abstraction over the
+ * {@link SuwayomiMetaClient} class and provides methods for retrieving data from the Suwayomi
+ * Server.
+ */
 @Service
 public class SuwayomiService {
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -30,7 +30,7 @@ public class SuwayomiService {
    * received.
    *
    * @return either the version of the Suwayomi Server if successful or an empty {@link Optional} if
-   * an error occurred.
+   *     an error occurred.
    */
   public Optional<ServerVersion> getServerVersion() {
     try {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -25,6 +25,13 @@ public class SuwayomiService {
     this.metaClient = metaClient;
   }
 
+  /**
+   * Retrieves the version of the Suwayomi Server. This method will block until the response is
+   * received.
+   *
+   * @return either the version of the Suwayomi Server if successful or an empty {@link Optional} if
+   * an error occurred.
+   */
   public Optional<ServerVersion> getServerVersion() {
     try {
       return Optional.of(metaClient.getServerVersion());

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/SuwayomiService.java
@@ -23,7 +23,9 @@ public class SuwayomiService {
 
   /**
    * Creates a new instance of the {@link SuwayomiService} class.
-   * @param metaClient the {@link SuwayomiMetaClient} used for retrieving data from the Suwayomi Server.
+   *
+   * @param metaClient the {@link SuwayomiMetaClient} used for retrieving data from the Suwayomi
+   *     Server.
    */
   public SuwayomiService(SuwayomiMetaClient metaClient) {
     this.metaClient = metaClient;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -21,7 +21,7 @@ public class SuwayomiMetaClient {
    * Creates a new instance of the {@link SuwayomiMetaClient} class.
    *
    * @param webClientService the {@link WebClientService} used for making API requests to the
-   *                         Suwayomi Server.
+   *     Suwayomi Server.
    */
   public SuwayomiMetaClient(WebClientService webClientService) {
     this.webClientService = webClientService;

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -11,7 +11,9 @@ import online.hatsunemiku.tachideskvaadinui.services.WebClientService;
 import org.intellij.lang.annotations.Language;
 import org.springframework.stereotype.Component;
 
-/** Retrieves metadata about the Suwayomi Server through its API. */
+/**
+ * Retrieves metadata about the Suwayomi Server through its API.
+ */
 @Component
 public class SuwayomiMetaClient {
 
@@ -21,19 +23,25 @@ public class SuwayomiMetaClient {
     this.webClientService = webClientService;
   }
 
+  /**
+   * Retrieves the version of the Suwayomi Server though its API. This method will block until the
+   * response is received.
+   *
+   * @return the version of the Suwayomi Server.
+   */
   public ServerVersion getServerVersion() {
     var client = webClientService.getDgsGraphQlClient();
 
     @Language("graphql")
     String query =
         """
-        query {
-          aboutServer {
-            version
-            revision
-          }
-        }
-        """;
+            query {
+              aboutServer {
+                version
+                revision
+              }
+            }
+            """;
 
     var response = client.reactiveExecuteQuery(query).block();
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -19,6 +19,12 @@ public class SuwayomiMetaClient {
 
   private final WebClientService webClientService;
 
+  /**
+   * Creates a new instance of the {@link SuwayomiMetaClient} class.
+   *
+   * @param webClientService the {@link WebClientService} used for making API requests to the
+   *                         Suwayomi Server.
+   */
   public SuwayomiMetaClient(WebClientService webClientService) {
     this.webClientService = webClientService;
   }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -11,9 +11,7 @@ import online.hatsunemiku.tachideskvaadinui.services.WebClientService;
 import org.intellij.lang.annotations.Language;
 import org.springframework.stereotype.Component;
 
-/**
- * Retrieves metadata about the Suwayomi Server through its API.
- */
+/** Retrieves metadata about the Suwayomi Server through its API. */
 @Component
 public class SuwayomiMetaClient {
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package online.hatsunemiku.tachideskvaadinui.services.client.suwayomi;
+
+import online.hatsunemiku.tachideskvaadinui.data.tachidesk.ServerVersion;
+import online.hatsunemiku.tachideskvaadinui.services.WebClientService;
+import org.intellij.lang.annotations.Language;
+import org.springframework.stereotype.Component;
+
+/**
+ * Retrieves metadata about the Suwayomi Server through its API.
+ */
+@Component
+public class SuwayomiMetaClient {
+
+  private final WebClientService webClientService;
+
+  public SuwayomiMetaClient(WebClientService webClientService) {
+    this.webClientService = webClientService;
+  }
+
+  public ServerVersion getServerVersion() {
+    var client = webClientService.getDgsGraphQlClient();
+
+    @Language("graphql")
+    String query = """
+        query {
+          aboutServer {
+            version
+            revision
+          }
+        }
+        """;
+
+    var response = client.reactiveExecuteQuery(query).block();
+
+    if (response == null) {
+      throw new RuntimeException("Failed to retrieve server version");
+    }
+
+    return response.extractValueAsObject("aboutServer", ServerVersion.class);
+  }
+
+}

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/client/suwayomi/SuwayomiMetaClient.java
@@ -11,9 +11,7 @@ import online.hatsunemiku.tachideskvaadinui.services.WebClientService;
 import org.intellij.lang.annotations.Language;
 import org.springframework.stereotype.Component;
 
-/**
- * Retrieves metadata about the Suwayomi Server through its API.
- */
+/** Retrieves metadata about the Suwayomi Server through its API. */
 @Component
 public class SuwayomiMetaClient {
 
@@ -27,7 +25,8 @@ public class SuwayomiMetaClient {
     var client = webClientService.getDgsGraphQlClient();
 
     @Language("graphql")
-    String query = """
+    String query =
+        """
         query {
           aboutServer {
             version
@@ -44,5 +43,4 @@ public class SuwayomiMetaClient {
 
     return response.extractValueAsObject("aboutServer", ServerVersion.class);
   }
-
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -71,7 +71,7 @@ public class TachideskStarter {
     log.info("Checking for java installation...");
     boolean isJavaInstalled;
     try {
-      Process process = Runtime.getRuntime().exec(new String[] {"java", "-version"});
+      Process process = Runtime.getRuntime().exec(new String[]{"java", "-version"});
       isJavaInstalled = process.waitFor() == 0;
     } catch (IOException | InterruptedException e) {
       log.error("Failed to check if java is installed");
@@ -162,6 +162,12 @@ public class TachideskStarter {
     startChecker = null;
   }
 
+  /**
+   * Checks if the server is running. It both checks if the server process exists and if the server
+   * is reachable and gives a valid response.
+   *
+   * @return {@code true} if the server is running, {@code false} otherwise.
+   */
   private boolean checkServerConnection() {
     if (serverProcess == null) {
       throw new RuntimeException("Server process is null");

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -71,7 +71,7 @@ public class TachideskStarter {
     log.info("Checking for java installation...");
     boolean isJavaInstalled;
     try {
-      Process process = Runtime.getRuntime().exec(new String[]{"java", "-version"});
+      Process process = Runtime.getRuntime().exec(new String[] {"java", "-version"});
       isJavaInstalled = process.waitFor() == 0;
     } catch (IOException | InterruptedException e) {
       log.error("Failed to check if java is installed");

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -45,11 +45,10 @@ public class TachideskStarter {
   /**
    * Creates a new instance of the {@link TachideskStarter} class.
    *
-   * @param settingsService      The {@link SettingsService} used for retrieving settings.
+   * @param settingsService The {@link SettingsService} used for retrieving settings.
    * @param serverEventPublisher The {@link ServerEventPublisher} used for publishing server events
-   *                             to the application.
-   * @param suwayomiApi          The {@link SuwayomiService} used for checking if the server is
-   *                             running.
+   *     to the application.
+   * @param suwayomiApi The {@link SuwayomiService} used for checking if the server is running.
    */
   public TachideskStarter(
       SettingsService settingsService,

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -39,7 +39,8 @@ public class TachideskStarter {
   private final SuwayomiService suwayomiApi;
 
   public TachideskStarter(
-      SettingsService settingsService, ServerEventPublisher serverEventPublisher,
+      SettingsService settingsService,
+      ServerEventPublisher serverEventPublisher,
       SuwayomiService suwayomiApi) {
     this.settingsService = settingsService;
     this.serverEventPublisher = serverEventPublisher;
@@ -66,7 +67,7 @@ public class TachideskStarter {
     log.info("Checking for java installation...");
     boolean isJavaInstalled;
     try {
-      Process process = Runtime.getRuntime().exec(new String[]{"java", "-version"});
+      Process process = Runtime.getRuntime().exec(new String[] {"java", "-version"});
       isJavaInstalled = process.waitFor() == 0;
     } catch (IOException | InterruptedException e) {
       log.error("Failed to check if java is installed");
@@ -171,8 +172,11 @@ public class TachideskStarter {
 
       var version = optional.get();
 
-      logger.info("Server version: Major={},Minor={},Patch={} with Revision={}",
-          version.getMajorVersion(), version.getMinorVersion(), version.getPatchVersion(),
+      logger.info(
+          "Server version: Major={},Minor={},Patch={} with Revision={}",
+          version.getMajorVersion(),
+          version.getMinorVersion(),
+          version.getPatchVersion(),
           version.getRevisionNumber());
       return true;
     } catch (Exception e) {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -42,6 +42,15 @@ public class TachideskStarter {
   private final ServerEventPublisher serverEventPublisher;
   private final SuwayomiService suwayomiApi;
 
+  /**
+   * Creates a new instance of the {@link TachideskStarter} class.
+   *
+   * @param settingsService      The {@link SettingsService} used for retrieving settings.
+   * @param serverEventPublisher The {@link ServerEventPublisher} used for publishing server events
+   *                             to the application.
+   * @param suwayomiApi          The {@link SuwayomiService} used for checking if the server is
+   *                             running.
+   */
   public TachideskStarter(
       SettingsService settingsService,
       ServerEventPublisher serverEventPublisher,

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -26,6 +26,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
+/**
+ * Is responsible for starting the Suwayomi (previously Tachidesk) server. Additionally, it checks
+ * if the server is running and publishes an event if it is.
+ */
 @Service
 @Slf4j
 public class TachideskStarter {


### PR DESCRIPTION
This PR adds a new API Service for Suwayomi, which gets Meta Information. So Information describing the Server itself. As of right now it only retrieves the Server Version and makes it easy to get individual parts of it. This will be used to make sure that dev work can be done on features/changes that aren't in a stable version yet, but when they arrive in a stable version VaadinUI will be able to work with the new setup without having to first receiving an update.