### PR TITLE
Sorted Chapters

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -86,7 +86,7 @@ public class Chapter implements Comparable<Chapter> {
    *     or greater than the specified chapter.
    */
   @Override
-  public int compareTo(@NotNull Chapter o) {
+  public int compareTo(@NotNull Chapter o) { // skipqc: JAVA-W1056
     if (Objects.equals(this, o)) {
       return 0;
     }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -7,6 +7,7 @@
 package online.hatsunemiku.tachideskvaadinui.data.tachidesk;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -84,6 +85,10 @@ public class Chapter implements Comparable<Chapter> {
    */
   @Override
   public int compareTo(@NotNull Chapter o) {
+    if (Objects.equals(this, o)) {
+      return 0;
+    }
+
     return Float.compare(chapterNumber, o.chapterNumber);
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -15,6 +15,9 @@ import lombok.NoArgsConstructor;
 import lombok.With;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Represents a chapter of a manga.
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -15,9 +15,7 @@ import lombok.NoArgsConstructor;
 import lombok.With;
 import org.jetbrains.annotations.NotNull;
 
-/**
- * Represents a chapter of a manga.
- */
+/** Represents a chapter of a manga. */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -79,8 +79,10 @@ public class Chapter implements Comparable<Chapter> {
 
   /**
    * Compares this chapter to another chapter based on the chapter number.
+   *
    * @param o the object to be compared.
-   * @return a negative integer, zero, or a positive integer as this chapter is less than, equal to, or greater than the specified chapter.
+   * @return a negative integer, zero, or a positive integer as this chapter is less than, equal to,
+   *     or greater than the specified chapter.
    */
   @Override
   public int compareTo(@NotNull Chapter o) {

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -12,13 +12,14 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.With;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @With
 @EqualsAndHashCode
-public class Chapter {
+public class Chapter implements Comparable<Chapter> {
 
   @JsonProperty("pageCount")
   private int pageCount;
@@ -74,5 +75,15 @@ public class Chapter {
   @Override
   public String toString() {
     return name;
+  }
+
+  /**
+   * Compares this chapter to another chapter based on the chapter number.
+   * @param o the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this chapter is less than, equal to, or greater than the specified chapter.
+   */
+  @Override
+  public int compareTo(@NotNull Chapter o) {
+    return Float.compare(chapterNumber, o.chapterNumber);
   }
 }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -82,8 +82,8 @@ public class MangaService {
 
   /**
    * Retrieves the cached list of chapters for a manga. This method does NOT find new chapters. Use
-   * {@link #fetchChapterList(int)} to find new chapters.
-   * This method also sorts the chapters by chapter number in ascending order.
+   * {@link #fetchChapterList(int)} to find new chapters. This method also sorts the chapters by
+   * chapter number in ascending order.
    *
    * @param mangaId the ID of the manga for which to get the chapter list
    * @return the list of Chapter objects representing the chapters of the manga

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/services/MangaService.java
@@ -83,23 +83,33 @@ public class MangaService {
   /**
    * Retrieves the cached list of chapters for a manga. This method does NOT find new chapters. Use
    * {@link #fetchChapterList(int)} to find new chapters.
+   * This method also sorts the chapters by chapter number in ascending order.
    *
    * @param mangaId the ID of the manga for which to get the chapter list
    * @return the list of Chapter objects representing the chapters of the manga
    */
   public List<Chapter> getChapterList(int mangaId) {
-    return mangaClient.getChapters(mangaId);
+    List<Chapter> chapters = mangaClient.getChapters(mangaId);
+
+    chapters.sort(Chapter::compareTo);
+
+    return chapters;
   }
 
   /**
    * Retrieves the list of chapters for a manga from the server. This method finds new chapters and
    * updates the cache. Use {@link #getChapterList(int)} to retrieve the cached list of chapters.
+   * This method also sorts the chapters by chapter number in ascending order.
    *
    * @param mangaId the ID of the manga for which to get the chapter list
    * @return the list of Chapter objects representing the chapters of the manga
    */
   public List<Chapter> fetchChapterList(int mangaId) {
-    return mangaClient.fetchChapterList(mangaId);
+    List<Chapter> chapters = mangaClient.fetchChapterList(mangaId);
+
+    chapters.sort(Chapter::compareTo);
+
+    return chapters;
   }
 
   @Cacheable(value = "chapter", key = "#chapterId", unless = "#result.pageCount == -1")


### PR DESCRIPTION
Chapters will now be sorted by their chapter number instead of by the order the Server returns them in.

Currently Chapters aren't sorted on the client side, so the server decides which order they have, which is usually fine, but I found a couple exception where they jumped around. e.g.
Chapter 40
Chapter 39
Chapter 1
Chapter 2
...

This Updated makes it, so the order is always determined by the chapter number instead. e.g. 
Chapter 1
Chapter 2
...
Chapter 39
Chapter 40