### PR TITLE
Fixes comments with a wrong keyword for static analysis exceptions

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/data/tachidesk/Chapter.java
@@ -87,7 +87,7 @@ public class Chapter implements Comparable<Chapter> {
    *     or greater than the specified chapter.
    */
   @Override
-  public int compareTo(@NotNull Chapter o) { // skipqc: JAVA-W1056
+  public int compareTo(@NotNull Chapter o) { // skipcq: JAVA-W1056
     if (Objects.equals(this, o)) {
       return 0;
     }

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/startup/TachideskStarter.java
@@ -119,7 +119,7 @@ public class TachideskStarter {
     serverChecker = Executors.newSingleThreadScheduledExecutor();
     startChecker = Executors.newSingleThreadScheduledExecutor();
 
-    // skipqc: JAVA-W1087
+    // skipcq: JAVA-W1087
     startChecker.scheduleAtFixedRate(this::checkIfServerIsRunning, 0, 5, TimeUnit.SECONDS);
   }
 

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/view/SearchView.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/view/SearchView.java
@@ -369,7 +369,7 @@ public class SearchView extends StandardLayout implements HasUrlParameter<String
 
     List<Manga> mangaList = new ArrayList<>();
 
-    // skipqc: JAVA-E0214
+    // skipcq: JAVA-E0214
     for (int i = 1; hasNext; i++) {
       SourceSearchResult searchResponse;
       try {


### PR DESCRIPTION
replaces all wrongly written keywords from `skipqc` to `skipcq`. 
Well yes I am stupid, how did you know?