### PR TITLE
Fix Sync Chapter progress when unread chapters are not in order

### DIFF
--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -117,7 +117,8 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
         e -> {
           if (e.getChapterNumbers().contains(chapter.getChapterNumber())) {
             addReadStatus(container);
-            var optional = rightSide
+            var optional =
+                rightSide
                     .getChildren()
                     .filter(btn -> btn instanceof Button)
                     .filter(btn -> btn.getId().orElse("").equals("read-button"))

--- a/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
+++ b/src/main/java/online/hatsunemiku/tachideskvaadinui/component/listbox/chapter/ChapterRenderer.java
@@ -117,13 +117,17 @@ public class ChapterRenderer extends ComponentRenderer<HorizontalLayout, Chapter
         e -> {
           if (e.getChapterNumbers().contains(chapter.getChapterNumber())) {
             addReadStatus(container);
-            var readBtn =
-                rightSide
+            var optional = rightSide
                     .getChildren()
                     .filter(btn -> btn instanceof Button)
                     .filter(btn -> btn.getId().orElse("").equals("read-button"))
-                    .findFirst()
-                    .orElseThrow();
+                    .findFirst();
+
+            if (optional.isEmpty()) {
+              return;
+            }
+
+            var readBtn = (Button) optional.get();
 
             rightSide.replace(readBtn, getUnreadButton(chapter, mangaService, rightSide));
           }


### PR DESCRIPTION
Fixes a problem where when syncing chapter progress with a tracker the readBtn would become null in specific circumstances and therefor throw an error